### PR TITLE
libopus build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "zstd"]
 	path = zstd
 	url = https://github.com/facebook/zstd.git
+[submodule "opus"]
+	path = opus
+	url = https://github.com/xiph/opus

--- a/doorstuck-opus.mk
+++ b/doorstuck-opus.mk
@@ -1,0 +1,42 @@
+# DOORSTUCK
+include opus/opus_sources.mk
+include opus/opus_headers.mk
+include opus/silk_sources.mk
+include opus/silk_headers.mk
+include opus/celt_sources.mk
+include opus/celt_headers.mk
+
+OPUS_PFX := opus/
+
+ALL_SOURCES := $(OPUS_SOURCES) $(OPUS_SOURCES_FLOAT)
+ALL_SOURCES += $(CELT_SOURCES) $(CELT_SOURCES_SSE) $(CELT_SOURCES_SSE2)
+ALL_SOURCES += $(SILK_SOURCES) $(SILK_SOURCES_FLOAT)
+
+ALL_HEADERS := $(OPUS_HEAD) $(SILK_HEAD) $(CELT_HEAD)
+
+ALL_SOURCES_PFX := $(addprefix $(OPUS_PFX),$(ALL_SOURCES))
+ALL_HEADERS_PFX := $(addprefix $(OPUS_PFX),$(ALL_HEADERS))
+
+# Includes
+OPUS_CFLAGS := -I $(OPUS_PFX) -I $(OPUS_PFX)include -I $(OPUS_PFX)celt -I $(OPUS_PFX)silk -I $(OPUS_PFX)silk/float
+# Defines
+OPUS_CFLAGS += -DUSE_ALLOCA -DOPUS_BUILD
+OPUS_CFLAGS += -DOPUS_X86_MAY_HAVE_SSE -DOPUS_X86_MAY_HAVE_SSE2
+OPUS_CFLAGS += -DOPUS_X86_PRESUME_SSE -DOPUS_X86_PRESUME_SSE2
+# Default to hidden visibility (Opus expects this and will override it's visibility for exports)
+OPUS_CFLAGS += -fvisibility=hidden
+
+# note the delayed evaluation
+OPUS_LDFLAGS = -shared -o $@
+
+all: builds/libopus.so builds/libopus.dll builds/libopus.dylib
+
+builds/libopus.so: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
+	zig cc -target x86_64-linux-gnu $(OPUS_CFLAGS) $(ALL_SOURCES_PFX) $(OPUS_LDFLAGS)
+
+builds/libopus.dll: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
+	zig cc -target x86_64-windows-gnu $(OPUS_CFLAGS) $(ALL_SOURCES_PFX) $(OPUS_LDFLAGS)
+
+builds/libopus.dylib: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
+	zig cc -target x86_64-macos-gnu $(OPUS_CFLAGS) $(ALL_SOURCES_PFX) $(OPUS_LDFLAGS)
+

--- a/linux/__build-opus.sh
+++ b/linux/__build-opus.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd /opt/linux
+
+mkdir build/
+mkdir build/opus
+
+# zig takes over the whole build, this isn't necessarily great for concurrency but let's not get in it's way, hmm?
+make -f opus.mk
+

--- a/linux/build-build-env.ps1
+++ b/linux/build-build-env.ps1
@@ -1,3 +1,3 @@
 #!/usr/bin/env pwsh
 
-docker build -t ss14-native-build:1.1 -f build-env.Dockerfile . 
+docker build -t ss14-native-build:1.0 -f build-env.Dockerfile . 

--- a/linux/build-build-env.ps1
+++ b/linux/build-build-env.ps1
@@ -1,3 +1,3 @@
 #!/usr/bin/env pwsh
 
-docker build -t ss14-native-build:1.0 -f build-env.Dockerfile . 
+docker build -t ss14-native-build:1.1 -f build-env.Dockerfile . 

--- a/linux/build-env.Dockerfile
+++ b/linux/build-env.Dockerfile
@@ -3,4 +3,11 @@ FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends xorg-dev gcc build-essential git make cmake libpulse-dev libasound-dev
 RUN apt-get install -y --no-install-recommends libglib2.0-dev
+# - 1.0 ends here -
+RUN apt-get install -y --no-install-recommends wget
+RUN wget --no-check-certificate https://ziglang.org/download/0.9.1/zig-linux-x86_64-0.9.1.tar.xz
+RUN echo be8da632c1d3273f766b69244d80669fe4f5e27798654681d77c992f17c237d7 zig-linux-x86_64-0.9.1.tar.xz | sha256sum -c -
+RUN tar -xJf zig-linux-x86_64-0.9.1.tar.xz ; mv zig-linux-x86_64-0.9.1 zig ; rm zig-linux-x86_64-0.9.1.tar.xz
+RUN ln -s /zig/zig /bin/zig
+# - 1.1 ends here -
 

--- a/linux/build-env.Dockerfile
+++ b/linux/build-env.Dockerfile
@@ -3,11 +3,11 @@ FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends xorg-dev gcc build-essential git make cmake libpulse-dev libasound-dev
 RUN apt-get install -y --no-install-recommends libglib2.0-dev
-# - 1.0 ends here -
+# ---
 RUN apt-get install -y --no-install-recommends wget
 RUN wget --no-check-certificate https://ziglang.org/download/0.9.1/zig-linux-x86_64-0.9.1.tar.xz
 RUN echo be8da632c1d3273f766b69244d80669fe4f5e27798654681d77c992f17c237d7 zig-linux-x86_64-0.9.1.tar.xz | sha256sum -c -
 RUN tar -xJf zig-linux-x86_64-0.9.1.tar.xz ; mv zig-linux-x86_64-0.9.1 zig ; rm zig-linux-x86_64-0.9.1.tar.xz
 RUN ln -s /zig/zig /bin/zig
-# - 1.1 ends here -
+# ---
 

--- a/linux/build-opus.ps1
+++ b/linux/build-opus.ps1
@@ -1,0 +1,9 @@
+#!/usr/bin/env pwsh
+
+docker run --rm -v "${pwd}/..:/opt" ss14-native-build:1.1 "/bin/bash" "/opt/linux/__build-opus.sh"
+
+new-item -Force -itemtype Directory ../builds/opus/
+copy-item build/opus/libopus.so.0 ../builds/opus/
+copy-item build/opus/libopus.dll ../builds/opus/
+copy-item build/opus/libopus.dylib ../builds/opus/
+

--- a/linux/build-opus.ps1
+++ b/linux/build-opus.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-docker run --rm -v "${pwd}/..:/opt" ss14-native-build:1.1 "/bin/bash" "/opt/linux/__build-opus.sh"
+docker run --rm -v "${pwd}/..:/opt" ss14-native-build:1.0 "/bin/bash" "/opt/linux/__build-opus.sh"
 
 new-item -Force -itemtype Directory ../builds/opus/
 copy-item build/opus/libopus.so.0 ../builds/opus/

--- a/linux/opus.mk
+++ b/linux/opus.mk
@@ -1,12 +1,13 @@
-# DOORSTUCK
-include opus/opus_sources.mk
-include opus/opus_headers.mk
-include opus/silk_sources.mk
-include opus/silk_headers.mk
-include opus/celt_sources.mk
-include opus/celt_headers.mk
+# Opus makefile using Zig to compile for Linux, Windows & Mac OS X
 
-OPUS_PFX := opus/
+include ../opus/opus_sources.mk
+include ../opus/opus_headers.mk
+include ../opus/silk_sources.mk
+include ../opus/silk_headers.mk
+include ../opus/celt_sources.mk
+include ../opus/celt_headers.mk
+
+OPUS_PFX := ../opus/
 
 ALL_SOURCES := $(OPUS_SOURCES) $(OPUS_SOURCES_FLOAT)
 ALL_SOURCES += $(CELT_SOURCES) $(CELT_SOURCES_SSE) $(CELT_SOURCES_SSE2)
@@ -29,14 +30,16 @@ OPUS_CFLAGS += -fvisibility=hidden
 # note the delayed evaluation
 OPUS_LDFLAGS = -shared -o $@
 
-all: builds/libopus.so builds/libopus.dll builds/libopus.dylib
+all: build/opus/libopus.so.0 build/opus/libopus.dll build/opus/libopus.dylib
 
-builds/libopus.so: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
+.PHONY: build/opus/libopus.so.0 build/opus/libopus.dll build/opus/libopus.dylib
+
+build/opus/libopus.so.0: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
 	zig cc -target x86_64-linux-gnu $(OPUS_CFLAGS) $(ALL_SOURCES_PFX) $(OPUS_LDFLAGS)
 
-builds/libopus.dll: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
+build/opus/libopus.dll: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
 	zig cc -target x86_64-windows-gnu $(OPUS_CFLAGS) $(ALL_SOURCES_PFX) $(OPUS_LDFLAGS)
 
-builds/libopus.dylib: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
+build/opus/libopus.dylib: $(ALL_SOURCES_PFX) $(ALL_HEADERS_PFX)
 	zig cc -target x86_64-macos-gnu $(OPUS_CFLAGS) $(ALL_SOURCES_PFX) $(OPUS_LDFLAGS)
 


### PR DESCRIPTION
Resulting binaries are not tested - but not that there'd be something to test it *on*.
I've confirmed at least it has the exports it's supposed to.

To help prevent a certain level of accidents, the Linux build is called `libopus.so.0`, so hopefully things will work by default.

The Windows DLL exports a bunch of symbols that it ought not to - if I had to take a wild guess I'd say this is Zig's way of smoothing over the differences between Linux and Windows symbol handling. It shouldn't do any harm.

Somewhat more concerning is that the MacOS build *also* exports a bunch of symbols, despite my visibility settings. Not sure how that will work out.