### PR TITLE
Build (or get) libraries for arm64, add swnfd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "zstd"]
 	path = zstd
 	url = https://github.com/facebook/zstd.git
+[submodule "swnfd"]
+	path = swnfd
+	url = https://github.com/space-wizards/nativefiledialog

--- a/macos/.gitignore
+++ b/macos/.gitignore
@@ -1,1 +1,2 @@
-build
+build/
+brewbuild/

--- a/macos/build-zstd.sh
+++ b/macos/build-zstd.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 
-mkdir build/
-mkdir build/zstd
+VERSION=1.5.2
+PLATFORM=osx-`uname -m`
+LIBRARY_NAME=zstd
+LIBRARY_FILE=lib/libzstd.dylib
 
-pushd build/zstd
 
-cmake ../../../zstd/build/cmake \
+# /-- boilerplate --\
+ANSI_GREEN='\033[0;32m'
+ANSI_RESET='\033[0m'
+
+INPUT_DIR=../$LIBRARY_NAME
+BUILD_DIR=build/$LIBRARY_NAME
+OUTPUT_DIR=../builds/$LIBRARY_NAME/$VERSION/$PLATFORM
+
+set -e 
+# \-- boilerplate --/
+
+
+# Actually do the build
+
+cmake -S $INPUT_DIR/build/cmake -B $BUILD_DIR \
     -DZSTD_BUILD_SHARED=ON \
     -DZSTD_BUILD_STATIC=OFF \
     -DZSTD_BUILD_PROGRAMS=OFF \
@@ -15,13 +30,13 @@ cmake ../../../zstd/build/cmake \
     -DZSTD_LEGACY_SUPPORT=OFF \
     -DCMAKE_BUILD_TYPE=Release
 
-# I don't know how to do nproc on mac and this 10 year old iMac has 4 cores so have fun.
-make -j 4
-
+pushd $BUILD_DIR
+make -j `sysctl -n hw.logicalcpu`
 popd
 
-mkdir ../builds
-mkdir ../builds/zstd
-mkdir ../builds/zstd/osx-x64
-cp build/zstd/lib/libzstd.dylib ../builds/zstd/osx-x64/libzstd.dylib
 
+# /-- boilerplate --\
+mkdir -p $OUTPUT_DIR
+cp $BUILD_DIR/$LIBRARY_FILE $OUTPUT_DIR/
+echo -e $ANSI_GREEN"Library file obtained: " `ls $OUTPUT_DIR` $ANSI_RESET
+# \-- boilerplate --/

--- a/macos/get-all.sh
+++ b/macos/get-all.sh
@@ -84,7 +84,6 @@ pushd ../builds
 
     brewgrab freetype 2.10.1 lib/libfreetype.6.dylib
     brewgrab glfw 3.3.2 lib/libglfw.3.dylib
-    brewgrab libsodium 1.0.18 lib/libsodium.dylib 
 
     # other archs are using 2.1.0 of fluidsynth but that patchlevel does not exist on brew
     brewgrab fluid-synth 2.1.8 lib/libfluidsynth.2.dylib fluidsynth

--- a/macos/get-all.sh
+++ b/macos/get-all.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+PLATFORM="osx-`uname -m`"
+ANSI_GREEN='\033[0;32m'
+ANSI_RESET='\033[0m'
+
+# set this to 1 if you want everything to be completely isolated from your global brew install,
+# but it forces some things to be built from source.
+USE_LOCAL_BUILD_ENV=
+
+brew install --quiet jq
+
+echo "Assembling native libraries for $PLATFORM..."
+
+if [ -z USE_LOCAL_BUILD_ENV ]; then
+
+    echo "Setting up homebrew build environment..."
+
+    git clone https://github.com/Homebrew/brew brewbuild
+    mkdir -p brewbuild
+    curl -L https://github.com/Homebrew/brew/tarball/3.6.7 | tar xz --strip 1 -C brewbuild
+    eval "$(brewbuild/bin/brew shellenv)"
+
+else
+
+    echo <<EOF 
+This will build using your global homebrew install. This may cause some errors to be 
+printed about linking, but if you have newer versions of the libraries this script 
+installs, these errors are because the old versions will not overwrite the new versions,
+and should be able to coexist without any problem.
+
+EOF
+
+fi
+
+set -e 
+brew -v
+set +e
+
+echo "Packages will be built at $HOMEBREW_PREFIX"
+
+# i find these names for things extremely stupid, but that's what brew calls them
+TAP_NAME=swbuild/local
+brew tap-new --no-git $TAP_NAME
+TAP_PATH=`brew tap-info --json swbuild/local | jq -r '.[0].path'`
+
+grab() {
+    output_dir=$1
+    version=$2
+    source=$3
+    
+    target=$output_dir/$version/$PLATFORM/
+
+    mkdir -p $target
+    chmod 0644 $source
+    cp -f $source $target
+    echo -e $ANSI_GREEN"Library file obtained: " `ls $target` $ANSI_RESET
+    echo
+}
+
+brewgrab() {
+    package=$1
+    version=$2
+    library_file=$3
+    output_dir=$4
+
+    if [ -z $output_dir ]; then output_dir=$package; fi
+
+    if [ ! -f "$TAP_PATH/Formula/$package@$version.rb" ]; then 
+        brew extract --version=$version $package $TAP_NAME
+    else
+        echo "Package build script already retrieved from github for $package@$version"
+    fi
+
+    brew install $package@$version
+    set -e
+    grab $output_dir $version "$HOMEBREW_PREFIX/Cellar/$package@$version/*/$library_file"
+    set +e
+}
+
+mkdir -p ../builds
+
+pushd ../builds
+
+    brewgrab freetype 2.10.1 lib/libfreetype.6.dylib
+    brewgrab glfw 3.3.2 lib/libglfw.3.dylib
+    brewgrab libsodium 1.0.18 lib/libsodium.dylib 
+
+    # other archs are using 2.1.0 of fluidsynth but that patchlevel does not exist on brew
+    brewgrab fluid-synth 2.1.8 lib/libfluidsynth.2.dylib fluidsynth
+
+    # we build zstd with different options than brew uses
+    # it would be:
+    #   brewgrab zstd 1.5.2 lib/libzstd.dylib
+popd
+
+
+echo "Building zstd..."
+set -e
+./build-zstd.sh
+set +e
+echo
+
+echo "Building swnfd..."
+set -e
+../swnfd/link_macos.sh
+grab swnfd 0.1.0 ../swnfd/build/darwin_multiarch/libswnfd.dylib 
+set +e
+
+echo
+ls ../builds/*/*/$PLATFORM/*
+echo -e $ANSI_GREEN"All done." $ANSI_RESET


### PR DESCRIPTION
Next step from https://github.com/space-wizards/nativefiledialog/pull/2

- Adds swnfd as a submodule here
- Adds a new script to reproducibly grab specific versions of native external dependencies from the homebrew package manager 
- Make the build-zstd.sh more templatey
